### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Giovanni Blu Mitolo <gioscarab@gmail.com>
 maintainer=Giovanni Blu Mitolo <gioscarab@gmail.com>
 sentence=Cape is a string encpryption library
 paragraph=Provides private key, an iteration tunable stream chipher algorithm with the addition of 1 byte initialization vector.
-category=Strings
+category=Data Processing
 url=https://github.com/gioblu/Cape
 architectures=avr


### PR DESCRIPTION
Fixes the 'WARNING: Category 'Strings' in library Cape is not valid. Setting to 'Uncategorized'' warning in Arduino IDE 1.6.6.