### PR TITLE
Optimise and simplify hash, encrypt and decrypt functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Cape 2.0
 ====
-Cape implements a new, private key / public salt, xor based, symmetric stream chipher along with a pseudo-random initialization vector asymmetric encryption algorithm, both originally developed to offer strong data security for limited microcontrollers.
+Cape implements a new, private key / public salt, xor based, symmetric stream cipher along with a pseudo-random initialization vector asymmetric encryption algorithm, both originally developed to offer strong data security for limited microcontrollers.
 
 ### How to use Cape
 Instantiate Cape passing the encryption key, its length and optionally the salt. The longer is the key the higher is the coverage `Cape` can offer. To have an acceptable level of security the encryption key should always be at least as long as the maximum data length transmitted. Adding salt higher data security, enabling to keep the same private key for a longer time, exchanging a new common salt once in a while if necessary. Salt must be exchanged encrypted (never transmit salt data in plain text).

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -30,7 +30,7 @@ class Cape {
       _key = key;
       _key_length = length;
       compute_reduced_key(key, length);
-    };
+    }
 
     /* Compute a 1 byte version of the encryption key */
     void compute_reduced_key(char *key, uint16_t length) {
@@ -38,7 +38,7 @@ class Cape {
       // Reduced key computation
       for(uint16_t i = 0; i < length; i++)
         _reduced_key ^= (key[i] << (i % 8));
-    };
+    }
 
     /* Decrypt data:
        (max 65535 characters) */
@@ -56,7 +56,7 @@ class Cape {
         );
       // 4 - Hash data with key (static symmetric hashing)
       hash(destination, destination, length);
-    };
+    }
 
     /* Stream chipher, private key, initialization vector based encryption
        algorithm (max 65535 characters):  */
@@ -79,7 +79,7 @@ class Cape {
       destination[length] ^= (_reduced_key ^ salt);
       // 4 - Further encrypt result and initialization vector
       hash(destination, destination, length + 1);
-    };
+    }
 
     /* Symmetric chiper using private key, reduced key and optionally salt:
        (max 65535 characters) */
@@ -89,14 +89,15 @@ class Cape {
           (_reduced_key ^ source[i] ^ salt ^ i) ^
           _key[(_reduced_key ^ salt ^ i) % _key_length]
         );
-    };
+    }
 
     /* Set or Change encryption key (max 65535 characters): */
     void set_key(char *key, uint16_t length) {
       _key = key;
       _key_length = length;
       compute_reduced_key(key, length);
-    };
+    }
+
   private:
     char *   _key;           // Keep private and safe
     uint16_t _key_length;    // Keep private and safe

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -43,19 +43,19 @@ class Cape {
     /* Decrypt data:
        (max 65534 characters) */
     void decrypt(char *source, char *destination, uint16_t length) {
-      // 1 - Hash data without triyng to decode initialization vector
-      hash(source, destination, length);
-      // 2 - Decrypt initialization vector
-      length = length - 1;
-      destination[length] ^= (_reduced_key ^ salt);
-      // 3 - Decrypt data with private key, reduced key and salt
-      for(uint16_t i = 0; i < length; i++)
-        destination[i] ^= (
-          (destination[length] ^ i) ^
-          _key[(salt ^ i ^ _reduced_key) % _key_length]
-        );
-      // 4 - Hash data with key (static symmetric hashing)
-      hash(destination, destination, length);
+      uint8_t lastIndex = length - 1;
+
+      // 1. Pre-hash salt and reduced key
+      uint8_t saltKey = salt ^ _reduced_key;
+
+      // 2. Decrypt initialisation vector using key, reduced key and salt
+      uint8_t iv = source[lastIndex] ^ lastIndex ^
+        _key[(lastIndex ^ saltKey) % _key_length];
+
+      // 3. Decrypt source data using key, initialisation vector, reduced key and salt
+      for (uint16_t i = 0; i < lastIndex; ++i)
+        destination[i] = source[i] ^ iv ^ i ^
+          _key[(saltKey ^ i) % _key_length];
     }
 
     /* Stream cipher, private key, initialization vector based encryption
@@ -66,19 +66,17 @@ class Cape {
       uint16_t length,
       uint8_t iv
     ) {
-      destination[length] = iv;
-      // 1 - Hash data with key (static symmetric hashing)
-      hash(source, destination, length);
-      // 2 - Encrypt data with private key, reduced key and salt
-      for(uint16_t i = 0; i < length; i++)
-        destination[i] ^= (
-          (destination[length] ^ i) ^
-          _key[(salt ^ i ^ _reduced_key) % _key_length]
-        );
-      // 3 - Encrypt initialization vector using reduced key and salt
-      destination[length] ^= (_reduced_key ^ salt);
-      // 4 - Further encrypt result and initialization vector
-      hash(destination, destination, length + 1);
+      // 1. Pre-hash salt and reduced key
+      uint8_t saltKey = salt ^ _reduced_key;
+
+      // 2. Encrypt initialisation vector using key, reduced key and salt
+      destination[length] = iv ^ length ^
+        _key[(length ^ saltKey) % _key_length];
+
+      // 3. Encrypt source data using key, initialisation vector, reduced key and salt
+      for (uint16_t i = 0; i < length; ++i)
+        destination[i] = source[i] ^ iv ^ i ^
+          _key[(saltKey ^ i) % _key_length];
     }
 
     /* Symmetric cipher using private key, reduced key and optionally salt:

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -81,7 +81,7 @@ class Cape {
       hash(destination, destination, length + 1);
     }
 
-    /* Symmetric chiper using private key, reduced key and optionally salt:
+    /* Symmetric cipher using private key, reduced key and optionally salt:
        (max 65534 characters) */
     void hash(char *source, char *destination, uint16_t length) {
       for(uint16_t i = 0; i < length; i++)

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -24,7 +24,7 @@ class Cape {
     char salt; // Salt used for encryption, can be exchanged if encrypted
 
     /* Instantiate Cape pass a pointer to the encryption key and its length:
-       (max 65535 characters) */
+       (max 65534 characters) */
     Cape(char *key, uint16_t length, uint8_t s = 0) {
       salt = s;
       _key = key;
@@ -41,7 +41,7 @@ class Cape {
     }
 
     /* Decrypt data:
-       (max 65535 characters) */
+       (max 65534 characters) */
     void decrypt(char *source, char *destination, uint16_t length) {
       // 1 - Hash data without triyng to decode initialization vector
       hash(source, destination, length);
@@ -59,7 +59,7 @@ class Cape {
     }
 
     /* Stream chipher, private key, initialization vector based encryption
-       algorithm (max 65535 characters):  */
+       algorithm (max 65534 characters):  */
     void encrypt(
       char *source,
       char *destination,
@@ -82,7 +82,7 @@ class Cape {
     }
 
     /* Symmetric chiper using private key, reduced key and optionally salt:
-       (max 65535 characters) */
+       (max 65534 characters) */
     void hash(char *source, char *destination, uint16_t length) {
       for(uint16_t i = 0; i < length; i++)
         destination[i] = (
@@ -91,7 +91,7 @@ class Cape {
         );
     }
 
-    /* Set or Change encryption key (max 65535 characters): */
+    /* Set or Change encryption key (max 65534 characters): */
     void set_key(char *key, uint16_t length) {
       _key = key;
       _key_length = length;

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -84,11 +84,12 @@ class Cape {
     /* Symmetric cipher using private key, reduced key and optionally salt:
        (max 65534 characters) */
     void hash(char *source, char *destination, uint16_t length) {
-      for(uint16_t i = 0; i < length; i++)
-        destination[i] = (
-          (_reduced_key ^ source[i] ^ salt ^ i) ^
-          _key[(_reduced_key ^ salt ^ i) % _key_length]
-        );
+      uint8_t saltKey = salt ^ _reduced_key;
+      for(uint16_t i = 0; i < length; i++) {
+        uint8_t iSaltKey = saltKey ^ i;
+        destination[i] = source[i] ^ iSaltKey ^
+          _key[iSaltKey % _key_length];
+        }
     }
 
     /* Set or Change encryption key (max 65534 characters): */

--- a/src/Cape.h
+++ b/src/Cape.h
@@ -58,7 +58,7 @@ class Cape {
       hash(destination, destination, length);
     }
 
-    /* Stream chipher, private key, initialization vector based encryption
+    /* Stream cipher, private key, initialization vector based encryption
        algorithm (max 65534 characters):  */
     void encrypt(
       char *source,

--- a/src/Cape_c.h
+++ b/src/Cape_c.h
@@ -106,7 +106,7 @@ void cape_decrypt(
   cape_hash(cape, destination, destination, length);
 };
 
-/* Stream chipher, private key, initialization vector based encryption
+/* Stream cipher, private key, initialization vector based encryption
    algorithm (max 65534 characters):  */
 void cape_encrypt(
   cape_t *cape,

--- a/src/Cape_c.h
+++ b/src/Cape_c.h
@@ -68,7 +68,7 @@ void cape_init(cape_t *cape, char *key, uint16_t length, uint8_t salt = 0) {
   cape->reduced_key = cape_compute_reduced_key(key, length);
 };
 
-/* Symmetric chiper using private key, reduced key and optionally salt:
+/* Symmetric cipher using private key, reduced key and optionally salt:
    (max 65534 characters) */
 void cape_hash(
   cape_t *cape,

--- a/src/Cape_c.h
+++ b/src/Cape_c.h
@@ -69,7 +69,7 @@ void cape_init(cape_t *cape, char *key, uint16_t length, uint8_t salt = 0) {
 };
 
 /* Symmetric chiper using private key, reduced key and optionally salt:
-   (max 65535 characters) */
+   (max 65534 characters) */
 void cape_hash(
   cape_t *cape,
   char *source,
@@ -84,7 +84,7 @@ void cape_hash(
 };
 
 /* Decrypt data:
-   (max 65535 characters) */
+   (max 65534 characters) */
 void cape_decrypt(
   cape_t *cape,
   char *source,
@@ -107,7 +107,7 @@ void cape_decrypt(
 };
 
 /* Stream chipher, private key, initialization vector based encryption
-   algorithm (max 65535 characters):  */
+   algorithm (max 65534 characters):  */
 void cape_encrypt(
   cape_t *cape,
   char *source,

--- a/src/Cape_c.h
+++ b/src/Cape_c.h
@@ -76,11 +76,12 @@ void cape_hash(
   char *destination,
   uint16_t length
 ) {
-  for(uint16_t i = 0; i < length; i++)
-    destination[i] = (
-      (cape->reduced_key ^ source[i] ^ cape->salt ^ i) ^
-      cape->key[(cape->reduced_key ^ cape->salt ^ i) % cape->length]
-    );
+  uint8_t saltKey = cape->salt ^ cape->reduced_key;
+  for(uint16_t i = 0; i < length; i++) {
+    uint8_t iSaltKey = saltKey ^ i;
+    destination[i] = source[i] ^ iSaltKey ^
+      cape->key[iSaltKey % cape->length];
+    }
 };
 
 /* Decrypt data:

--- a/src/Cape_c.h
+++ b/src/Cape_c.h
@@ -92,19 +92,20 @@ void cape_decrypt(
   char *destination,
   uint16_t length
 ) {
-  // 1 - Hash data without triyng to decode initialization vector
-  cape_hash(cape, source, destination, length);
-  // 2 - Decrypt initialization vector
-  length = length - 1;
-  destination[length] ^= (cape->reduced_key ^ cape->salt);
-  // 3 - Decrypt data with private key, reduced key and salt
-  for(uint16_t i = 0; i < length; i++)
-    destination[i] ^= (
-      (destination[length] ^ i) ^
-      cape->key[(cape->salt ^ i ^ cape->reduced_key) % cape->length]
-    );
-  // 4 - Hash data with key (static symmetric hashing)
-  cape_hash(cape, destination, destination, length);
+  uint8_t lastIndex = length - 1;
+
+  // 1. Pre-hash salt and reduced key
+  uint8_t saltKey = salt ^ _reduced_key;
+
+  // 2. Decrypt initialisation vector using key, reduced key and salt
+  uint8_t iv = source[lastIndex] ^ lastIndex ^
+    _key[(lastIndex ^ saltKey) % _key_length];
+
+  // 3. Decrypt source data using key, initialisation vector, reduced key and salt
+  for (uint16_t i = 0; i < lastIndex; ++i)
+    destination[i] = source[i] ^ iv ^ i ^
+      _key[(saltKey ^ i) % _key_length];
+    }
 };
 
 /* Stream cipher, private key, initialization vector based encryption
@@ -116,17 +117,15 @@ void cape_encrypt(
   uint16_t length,
   uint8_t iv
 ) {
-  destination[length] = iv;
-  // 1 - Hash data with key (static symmetric hashing)
-  cape_hash(cape, source, destination, length);
-  // 2 - Encrypt data with private key, reduced key and salt
-  for(uint16_t i = 0; i < length; i++)
-    destination[i] ^= (
-      (destination[length] ^ i) ^
-      cape->key[(cape->salt ^ i ^ cape->reduced_key) % cape->length]
-    );
-  // 3 - Encrypt initialization vector using reduced key and salt
-  destination[length] ^= (cape->reduced_key ^ cape->salt);
-  // 4 - Further encrypt result and initialization vector
-  cape_hash(cape, destination, destination, length + 1);
+  // 1. Pre-hash salt and reduced key
+  uint8_t saltKey = salt ^ _reduced_key;
+
+  // 2. Encrypt initialisation vector using key, reduced key and salt
+  destination[length] = iv ^ length ^
+    _key[(lastIndex ^ saltKey) % _key_length];
+
+  // 3. Encrypt source data using key, initialisation vector, reduced key and salt
+  for (uint16_t i = 0; i < length; ++i)
+    destination[i] = source[i] ^ iv ^ i ^
+      _key[(saltKey ^ i) % _key_length];
 };


### PR DESCRIPTION
I applied the changes to both the original C++ version of cape and the C version of cape.
The C++ version definitely works but the C version might need verifying/tweaking since I don't know as much about the rules of C.

I also made some spelling corrections, corrected the specified max character limit and rewrote the comments in `encrypt` and `decrypt` to match the new behaviour.

