### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,18 +6,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Cape  KEYWORD1
+Cape	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 
-hash            KEYWORD2
-decrypt         KEYWORD2
-encrypt         KEYWORD2
-salt            KEYWORD2
-set_key         KEYWORD2
+hash	KEYWORD2
+decrypt	KEYWORD2
+encrypt	KEYWORD2
+salt	KEYWORD2
+set_key	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords